### PR TITLE
feat(core): :tada: finalize visitors and RENIEC/SUNAT

### DIFF
--- a/src/config/env/index.ts
+++ b/src/config/env/index.ts
@@ -1,3 +1,4 @@
+//src/config/env/index.ts
 import { config } from "dotenv";
 
 config();
@@ -18,7 +19,8 @@ export const API_KEY_GEMINI = process.env.API_KEY_GEMINI;
 export const JWT_SECRET = process.env.JWT_SECRET;
 
 // QR CODE
-export const QR_CODE_ALPHABET = process.env.QR_CODE_ALPHABET ?? "1234567890abcdef";
+export const QR_CODE_ALPHABET =
+  process.env.QR_CODE_ALPHABET ?? "1234567890abcdef";
 export const QR_CODE_LENGTH = Number(process.env.QR_CODE_LENGTH ?? 10);
 
 // SERVER
@@ -42,3 +44,7 @@ export const EMAIL_PASSWORD = process.env.EMAIL_PASSWORD;
 export const SMTP_HOST = process.env.SMTP_HOST;
 export const SMTP_PORT = process.env.SMTP_PORT;
 
+//RENIEC (DECOLECTA)
+export const DECOLECTA_API_KEY = process.env.DECOLECTA_API_KEY;
+export const DECOLECTA_BASE_URL =
+  process.env.DECOLECTA_BASE_URL ?? "https://api.decolecta.com";

--- a/src/constants/messages/index.ts
+++ b/src/constants/messages/index.ts
@@ -7,6 +7,7 @@ import { NEWSLETTER_MESSAGES } from "./newsletter";
 import { PRODUCT_MESSAGES } from "./product";
 import { PAYMENT_MESSAGES } from "./payment";
 import { BRAND_MESSAGES } from "./brand";
+import { VISITOR_MESSAGES } from "./visitor";
 
 export const MESSAGES = {
   ARTICLE: ARTICLE_MESSAGES,
@@ -17,4 +18,5 @@ export const MESSAGES = {
   NEWSLETTER: NEWSLETTER_MESSAGES,
   PRODUCT: PRODUCT_MESSAGES,
   BRAND: BRAND_MESSAGES,
+  VISITOR: VISITOR_MESSAGES,
 };

--- a/src/constants/messages/visitor/index.ts
+++ b/src/constants/messages/visitor/index.ts
@@ -1,0 +1,12 @@
+export const VISITOR_MESSAGES = {
+  CREATED_SUCCESS: "Visitor created successfully",
+  UPDATED_SUCCESS: "Visitor updated successfully",
+  DELETED_SUCCESS: "Visitor deleted successfully",
+  NOT_FOUND: "Visitor not found",
+  FORBIDDEN: "You are not allowed to perform this action",
+  HOST_NOT_FOUND: "Host (employee) not found",
+  SPACE_NOT_FOUND: "Space not found",
+  ALREADY_CHECKED_OUT: "Visitor already has an exit time",
+  LOOKUP_NOT_FOUND: "No record found for given ID",
+  LOOKUP_BAD_REQUEST: "Invalid ID format",
+};

--- a/src/modules/seed/data/seed.repository.ts
+++ b/src/modules/seed/data/seed.repository.ts
@@ -488,4 +488,4 @@ export class SeedRepository {
 
     return { message: "Database seeded successfully" };
   }
-} // 👈 esta llave faltaba
+}

--- a/src/modules/visitor/features/create_visitor/data/create_visitor.repository.ts
+++ b/src/modules/visitor/features/create_visitor/data/create_visitor.repository.ts
@@ -1,0 +1,26 @@
+// src/modules/visitor/features/create_visitor/data/create_visitor.repository.ts
+import prisma from "../../../../../config/prisma_client";
+
+export class CreateVisitorRepository {
+  findHostByEmployeeId(employee_id: string) {
+    return prisma.employee_details.findUnique({ where: { employee_id } });
+  }
+  findSpaceById(space_id: string) {
+    return prisma.space.findUnique({ where: { id: space_id } });
+  }
+  create(data: {
+    dni?: string | null;
+    ruc?: string | null;
+    first_name: string;
+    last_name: string;
+    phone?: string | null;
+    email?: string | null;
+    company?: string | null;
+    employee_id: string;
+    space_id: string;
+    entry_time: Date;
+    exit_time?: Date | null;
+  }) {
+    return prisma.visitors.create({ data });
+  }
+}

--- a/src/modules/visitor/features/create_visitor/domain/create_visitor.dto.ts
+++ b/src/modules/visitor/features/create_visitor/domain/create_visitor.dto.ts
@@ -1,0 +1,5 @@
+// src/modules/visitor/features/create_visitor/domain/create_visitor.dto.ts
+import { z } from "zod";
+import { CreateVisitorSchema } from "./create_visitor.schema";
+
+export type CreateVisitorDTO = z.infer<typeof CreateVisitorSchema>;

--- a/src/modules/visitor/features/create_visitor/domain/create_visitor.schema.ts
+++ b/src/modules/visitor/features/create_visitor/domain/create_visitor.schema.ts
@@ -1,0 +1,39 @@
+// src/modules/visitor/features/create_visitor/domain/create_visitor.schema.ts
+import { z } from "zod";
+
+const onlyDigits = (len: number) =>
+  z
+    .string()
+    .trim()
+    .regex(new RegExp(`^\\d{${len}}$`), `must be ${len} digits`);
+
+export const CreateVisitorSchema = z
+  .object({
+    dni: onlyDigits(8).optional(),
+    ruc: onlyDigits(11).optional(),
+    first_name: z.string().min(1),
+    last_name: z.string().min(1),
+    phone: z.string().optional(),
+    email: z.string().email().optional(),
+    company: z.string().optional(),
+    employee_id: z.string().uuid(),
+    space_id: z.string().uuid(),
+    entry_time: z.string().datetime(),
+    exit_time: z.string().datetime().optional(),
+  })
+  .refine((v) => !(v.dni && v.ruc), {
+    message: "dni and ruc are mutually exclusive",
+    path: ["dni"],
+  })
+  .refine(
+    (v) => {
+      if (!v.exit_time) return true;
+      return (
+        new Date(v.exit_time).getTime() >= new Date(v.entry_time).getTime()
+      );
+    },
+    {
+      message: "exit_time must be >= entry_time",
+      path: ["exit_time"],
+    },
+  );

--- a/src/modules/visitor/features/create_visitor/index.ts
+++ b/src/modules/visitor/features/create_visitor/index.ts
@@ -1,0 +1,1 @@
+import { createAndLookupVisitorRoutes } from "./service/create_visitor.routes";

--- a/src/modules/visitor/features/create_visitor/service/create_visitor.controller.ts
+++ b/src/modules/visitor/features/create_visitor/service/create_visitor.controller.ts
@@ -1,0 +1,31 @@
+// src/modules/visitor/features/create_visitor/service/create_visitor.controller.ts
+import { Response } from "express";
+import { CreateVisitorService } from "./create_visitor.service";
+import { CreateVisitorSchema } from "../domain/create_visitor.schema";
+import { buildHttpResponse } from "../../../../../utils/build_http_response";
+import { HttpStatusCodes } from "../../../../../constants/http_status_codes";
+import { getAuthenticatedUser } from "../../../../../utils/authenticated_user";
+import { AuthenticatedRequest } from "../../../../../middlewares/authenticate_token";
+
+export class CreateVisitorController {
+  constructor(private readonly service = new CreateVisitorService()) {}
+
+  async handle(req: AuthenticatedRequest, res: Response) {
+    const dto = CreateVisitorSchema.parse(req.body);
+    const user = await getAuthenticatedUser(req);
+    const result = await this.service.execute(dto, user);
+
+    return res.status(HttpStatusCodes.CREATED.code).json(
+      buildHttpResponse(
+        HttpStatusCodes.CREATED.code,
+        result.message,
+        req.path,
+        {
+          id: result.id,
+          first_name: dto.first_name,
+          last_name: dto.last_name,
+        },
+      ),
+    );
+  }
+}

--- a/src/modules/visitor/features/create_visitor/service/create_visitor.routes.ts
+++ b/src/modules/visitor/features/create_visitor/service/create_visitor.routes.ts
@@ -1,0 +1,82 @@
+// src/modules/visitor/features/create_visitor/service/create_visitor.routes.ts
+import { Router } from "express";
+import { authenticateToken } from "../../../../../middlewares/authenticate_token";
+import { asyncHandler } from "../../../../../middlewares/async_handler";
+import { CreateVisitorController } from "../../create_visitor/service/create_visitor.controller";
+import { LookupVisitorController } from "../../lookup_visitor/presentation/lookup.controller";
+
+const router = Router();
+const createCtrl = new CreateVisitorController();
+const lookupCtrl = new LookupVisitorController();
+
+/**
+ * @openapi
+ * /api/v1/visitors:
+ *   post:
+ *     tags: [Visitor]
+ *     summary: Crear visitante (manual o con datos del lookup)
+ *     security: [ { bearerAuth: [] } ]
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               dni: { type: string, example: "46027897" }
+ *               ruc: { type: string, example: "20601030013" }
+ *               first_name: { type: string, example: "ROXANA KARINA" }
+ *               last_name: { type: string, example: "DELGADO CUELLAR" }
+ *               phone: { type: string, example: "999888777" }
+ *               email: { type: string, example: "rdelgado@example.com" }
+ *               company: { type: string, example: "REXTIE S.A.C." }
+ *               employee_id: { type: string, format: uuid }
+ *               space_id: { type: string, format: uuid }
+ *               entry_time: { type: string, format: date-time }
+ *               exit_time: { type: string, format: date-time }
+ *           examples:
+ *             manual:
+ *               value:
+ *                 first_name: "Juan"
+ *                 last_name: "Pérez"
+ *                 employee_id: "uuid-emp"
+ *                 space_id: "uuid-space"
+ *                 entry_time: "2025-08-08T15:30:00.000Z"
+ *             with_lookup_dni:
+ *               value:
+ *                 dni: "46027897"
+ *                 first_name: "ROXANA KARINA"
+ *                 last_name: "DELGADO CUELLAR"
+ *                 employee_id: "uuid-emp"
+ *                 space_id: "uuid-space"
+ *                 entry_time: "2025-08-08T15:30:00.000Z"
+ */
+
+router.post(
+  "/",
+  authenticateToken,
+  asyncHandler(createCtrl.handle.bind(createCtrl)),
+);
+
+/**
+ * @openapi
+ * /api/v1/visitors/lookup:
+ *   get:
+ *     tags: [Visitor]
+ *     summary: Buscar datos en RENIEC/SUNAT
+ *     parameters:
+ *       - in: query
+ *         name: dni
+ *         schema: { type: string, example: "12345678" }
+ *       - in: query
+ *         name: ruc
+ *         schema: { type: string, example: "20123456789" }
+ *     security: [ { bearerAuth: [] } ]
+ */
+router.get(
+  "/lookup",
+  authenticateToken,
+  asyncHandler(lookupCtrl.handle.bind(lookupCtrl)),
+);
+
+export { router as createAndLookupVisitorRoutes };

--- a/src/modules/visitor/features/create_visitor/service/create_visitor.service.ts
+++ b/src/modules/visitor/features/create_visitor/service/create_visitor.service.ts
@@ -1,0 +1,52 @@
+// src/modules/visitor/features/create_visitor/service/create_visitor.service.ts
+import { CreateVisitorRepository } from "../data/create_visitor.repository";
+import { CreateVisitorDTO } from "../domain/create_visitor.dto";
+import { AppError } from "../../../../../utils/errors";
+import { HttpStatusCodes } from "../../../../../constants/http_status_codes";
+import { MESSAGES } from "../../../../../constants/messages";
+import type { CurrentUser } from "../../../../../utils/authenticated_user";
+
+export class CreateVisitorService {
+  constructor(private readonly repo = new CreateVisitorRepository()) {}
+
+  async execute(dto: CreateVisitorDTO, user: Pick<CurrentUser, "id" | "role">) {
+    if (user.role !== "admin") {
+      throw new AppError(
+        MESSAGES.VISITOR.FORBIDDEN,
+        HttpStatusCodes.FORBIDDEN.code,
+      );
+    }
+
+    const host = await this.repo.findHostByEmployeeId(dto.employee_id);
+    if (!host) {
+      throw new AppError(
+        MESSAGES.VISITOR.HOST_NOT_FOUND,
+        HttpStatusCodes.BAD_REQUEST.code,
+      );
+    }
+
+    const space = await this.repo.findSpaceById(dto.space_id);
+    if (!space) {
+      throw new AppError(
+        MESSAGES.VISITOR.SPACE_NOT_FOUND,
+        HttpStatusCodes.BAD_REQUEST.code,
+      );
+    }
+
+    const created = await this.repo.create({
+      dni: dto.dni ?? null,
+      ruc: dto.ruc ?? null,
+      first_name: dto.first_name,
+      last_name: dto.last_name,
+      phone: dto.phone ?? null,
+      email: dto.email ?? null,
+      company: dto.company ?? null,
+      employee_id: dto.employee_id,
+      space_id: dto.space_id,
+      entry_time: new Date(dto.entry_time),
+      exit_time: dto.exit_time ? new Date(dto.exit_time) : null,
+    });
+
+    return { id: created.id, message: MESSAGES.VISITOR.CREATED_SUCCESS };
+  }
+}

--- a/src/modules/visitor/features/delete_visitor/data/delete_visitor.repository.ts
+++ b/src/modules/visitor/features/delete_visitor/data/delete_visitor.repository.ts
@@ -1,0 +1,11 @@
+// src/modules/visitor/features/delete_visitor/data/delete_visitor.repository.ts
+import prisma from "../../../../../config/prisma_client";
+
+export class DeleteVisitorRepository {
+  findById(id: string) {
+    return prisma.visitors.findUnique({ where: { id } });
+  }
+  delete(id: string) {
+    return prisma.visitors.delete({ where: { id } });
+  }
+}

--- a/src/modules/visitor/features/delete_visitor/presentation/delete_visitor.controller.ts
+++ b/src/modules/visitor/features/delete_visitor/presentation/delete_visitor.controller.ts
@@ -1,0 +1,22 @@
+// src/modules/visitor/features/delete_visitor/presentation/delete_visitor.controller.ts
+import { Response } from "express";
+import { buildHttpResponse } from "../../../../../utils/build_http_response";
+import { HttpStatusCodes } from "../../../../../constants/http_status_codes";
+import { AuthenticatedRequest } from "../../../../../middlewares/authenticate_token";
+import { getAuthenticatedUser } from "../../../../../utils/authenticated_user";
+import { DeleteVisitorService } from "./delete_visitor.service";
+
+export class DeleteVisitorController {
+  constructor(private readonly service = new DeleteVisitorService()) {}
+
+  async handle(req: AuthenticatedRequest, res: Response) {
+    const { id } = req.params;
+    const user = await getAuthenticatedUser(req);
+    const result = await this.service.execute(id, user);
+    return res
+      .status(HttpStatusCodes.OK.code)
+      .json(
+        buildHttpResponse(HttpStatusCodes.OK.code, result.message, req.path),
+      );
+  }
+}

--- a/src/modules/visitor/features/delete_visitor/presentation/delete_visitor.routes.ts
+++ b/src/modules/visitor/features/delete_visitor/presentation/delete_visitor.routes.ts
@@ -1,0 +1,44 @@
+// src/modules/visitor/features/delete_visitor/presentation/delete_visitor.routes.ts
+import { Router } from "express";
+import { asyncHandler } from "../../../../../middlewares/async_handler";
+import { authenticateToken } from "../../../../../middlewares/authenticate_token";
+import { DeleteVisitorController } from "./delete_visitor.controller";
+
+const router = Router();
+const controller = new DeleteVisitorController();
+
+/**
+ * @openapi
+ * /api/v1/visitors/{id}:
+ *   delete:
+ *     tags: [Visitor]
+ *     summary: Eliminar un visitante
+ *     description: |
+ *       Elimina un registro de visitante. Solo **admin**.
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *           format: uuid
+ *         description: ID del visitante a eliminar
+ *     responses:
+ *       200:
+ *         description: Visitante eliminado correctamente
+ *       401:
+ *         description: No autenticado
+ *       403:
+ *         description: No autorizado para eliminar
+ *       404:
+ *         description: Visitante no encontrado
+ */
+router.delete(
+  "/:id",
+  authenticateToken,
+  asyncHandler(controller.handle.bind(controller)),
+);
+
+export { router as deleteVisitorRoutes };

--- a/src/modules/visitor/features/delete_visitor/presentation/delete_visitor.service.ts
+++ b/src/modules/visitor/features/delete_visitor/presentation/delete_visitor.service.ts
@@ -1,0 +1,28 @@
+// src/modules/visitor/features/delete_visitor/presentation/delete_visitor.service.ts
+import { DeleteVisitorRepository } from "../data/delete_visitor.repository";
+import { AppError } from "../../../../../utils/errors";
+import { HttpStatusCodes } from "../../../../../constants/http_status_codes";
+import { MESSAGES } from "../../../../../constants/messages";
+import type { CurrentUser } from "../../../../../utils/authenticated_user";
+
+export class DeleteVisitorService {
+  constructor(private readonly repo = new DeleteVisitorRepository()) {}
+
+  async execute(id: string, user: Pick<CurrentUser, "id" | "role">) {
+    if (user.role !== "admin") {
+      throw new AppError(
+        MESSAGES.VISITOR.FORBIDDEN,
+        HttpStatusCodes.FORBIDDEN.code,
+      );
+    }
+    const existing = await this.repo.findById(id);
+    if (!existing)
+      throw new AppError(
+        MESSAGES.VISITOR.NOT_FOUND,
+        HttpStatusCodes.NOT_FOUND.code,
+      );
+
+    await this.repo.delete(id);
+    return { message: MESSAGES.VISITOR.DELETED_SUCCESS };
+  }
+}

--- a/src/modules/visitor/features/edit_visitor/data/edit_visitor.repository.ts
+++ b/src/modules/visitor/features/edit_visitor/data/edit_visitor.repository.ts
@@ -1,0 +1,23 @@
+// src/modules/visitor/features/edit_visitor/data/edit_visitor.repository.ts
+import prisma from "../../../../../config/prisma_client";
+
+export class EditVisitorRepository {
+  findById(id: string) {
+    return prisma.visitors.findUnique({ where: { id } });
+  }
+  update(
+    id: string,
+    data: Partial<{
+      phone: string | null;
+      email: string | null;
+      company: string | null;
+      exit_time: Date | null;
+      space_id: string;
+    }>,
+  ) {
+    return prisma.visitors.update({ where: { id }, data });
+  }
+  findSpaceById(space_id: string) {
+    return prisma.space.findUnique({ where: { id: space_id } });
+  }
+}

--- a/src/modules/visitor/features/edit_visitor/domain/edit_visitor.schema.ts
+++ b/src/modules/visitor/features/edit_visitor/domain/edit_visitor.schema.ts
@@ -1,0 +1,10 @@
+// src/modules/visitor/features/edit_visitor/domain/edit_visitor.schema.ts
+import { z } from "zod";
+
+export const EditVisitorSchema = z.object({
+  phone: z.string().optional(),
+  email: z.string().email().optional(),
+  company: z.string().optional(),
+  exit_time: z.string().datetime().optional(), // para checkout
+  space_id: z.string().uuid().optional(), // si cambió de espacio
+});

--- a/src/modules/visitor/features/edit_visitor/presentation/edit_visitor.controller.ts
+++ b/src/modules/visitor/features/edit_visitor/presentation/edit_visitor.controller.ts
@@ -1,0 +1,25 @@
+// src/modules/visitor/features/edit_visitor/presentation/edit_visitor.controller.ts
+import { Response } from "express";
+import { buildHttpResponse } from "../../../../../utils/build_http_response";
+import { HttpStatusCodes } from "../../../../../constants/http_status_codes";
+import { EditVisitorService } from "./edit_visitor.service";
+import { EditVisitorSchema } from "../domain/edit_visitor.schema";
+import type { AuthenticatedRequest } from "../../../../../middlewares/authenticate_token";
+import { getAuthenticatedUser } from "../../../../../utils/authenticated_user";
+
+export class EditVisitorController {
+  constructor(private readonly service = new EditVisitorService()) {}
+
+  async handle(req: AuthenticatedRequest, res: Response) {
+    const body = EditVisitorSchema.parse(req.body);
+    const { id } = req.params;
+    const user = await getAuthenticatedUser(req);
+
+    const result = await this.service.execute(id, body, user);
+    return res.status(HttpStatusCodes.OK.code).json(
+      buildHttpResponse(HttpStatusCodes.OK.code, result.message, req.path, {
+        id: result.id,
+      }),
+    );
+  }
+}

--- a/src/modules/visitor/features/edit_visitor/presentation/edit_visitor.routes.ts
+++ b/src/modules/visitor/features/edit_visitor/presentation/edit_visitor.routes.ts
@@ -1,0 +1,71 @@
+// src/modules/visitor/features/edit_visitor/presentation/edit_visitor.routes.ts
+import { Router } from "express";
+import { asyncHandler } from "../../../../../middlewares/async_handler";
+import { authenticateToken } from "../../../../../middlewares/authenticate_token";
+import { EditVisitorController } from "./edit_visitor.controller";
+
+const router = Router();
+const controller = new EditVisitorController();
+
+/**
+ * @openapi
+ * /api/v1/visitors/{id}:
+ *   put:
+ *     tags: [Visitor]
+ *     summary: Editar un visitante (checkout o actualizar datos)
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *           format: uuid
+ *         description: ID del visitante a editar
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               phone:
+ *                 type: string
+ *                 example: "987654321"
+ *               email:
+ *                 type: string
+ *                 format: email
+ *                 example: "visitante@example.com"
+ *               company:
+ *                 type: string
+ *                 example: "Alicorp"
+ *               exit_time:
+ *                 type: string
+ *                 format: date-time
+ *                 example: "2025-08-25T17:00:00.000Z"
+ *               space_id:
+ *                 type: string
+ *                 format: uuid
+ *                 description: Nuevo espacio si cambió durante la visita
+ *     responses:
+ *       200:
+ *         description: Visitante actualizado correctamente
+ *       400:
+ *         description: Datos inválidos o espacio no encontrado
+ *       401:
+ *         description: No autenticado
+ *       403:
+ *         description: No autorizado para editar
+ *       404:
+ *         description: Visitante no encontrado
+ *       409:
+ *         description: El visitante ya tenía registrada la salida
+ */
+router.put(
+  "/:id",
+  authenticateToken,
+  asyncHandler(controller.handle.bind(controller)),
+);
+
+export { router as editVisitorRoutes };

--- a/src/modules/visitor/features/edit_visitor/presentation/edit_visitor.service.ts
+++ b/src/modules/visitor/features/edit_visitor/presentation/edit_visitor.service.ts
@@ -1,0 +1,59 @@
+// src/modules/visitor/features/edit_visitor/presentation/edit_visitor.service.ts
+import { EditVisitorRepository } from "../data/edit_visitor.repository";
+import { AppError } from "../../../../../utils/errors";
+import { HttpStatusCodes } from "../../../../../constants/http_status_codes";
+import { MESSAGES } from "../../../../../constants/messages";
+import type { CurrentUser } from "../../../../../utils/authenticated_user";
+import { z } from "zod";
+import { EditVisitorSchema } from "../domain/edit_visitor.schema";
+
+export class EditVisitorService {
+  constructor(private readonly repo = new EditVisitorRepository()) {}
+
+  async execute(
+    id: string,
+    body: z.infer<typeof EditVisitorSchema>,
+    user: Pick<CurrentUser, "id" | "role">,
+  ) {
+    if (user.role !== "admin") {
+      throw new AppError(
+        MESSAGES.VISITOR.FORBIDDEN,
+        HttpStatusCodes.FORBIDDEN.code,
+      );
+    }
+
+    const existing = await this.repo.findById(id);
+    if (!existing)
+      throw new AppError(
+        MESSAGES.VISITOR.NOT_FOUND,
+        HttpStatusCodes.NOT_FOUND.code,
+      );
+
+    if (body.space_id) {
+      const space = await this.repo.findSpaceById(body.space_id);
+      if (!space)
+        throw new AppError(
+          MESSAGES.VISITOR.SPACE_NOT_FOUND,
+          HttpStatusCodes.BAD_REQUEST.code,
+        );
+    }
+
+    // Evitar pisar salida si ya se registró
+    if (existing.exit_time && body.exit_time) {
+      throw new AppError(
+        MESSAGES.VISITOR.ALREADY_CHECKED_OUT,
+        HttpStatusCodes.CONFLICT.code,
+      );
+    }
+
+    const updated = await this.repo.update(id, {
+      phone: body.phone ?? null,
+      email: body.email ?? null,
+      company: body.company ?? null,
+      exit_time: body.exit_time ? new Date(body.exit_time) : undefined,
+      space_id: body.space_id ?? undefined,
+    });
+
+    return { id: updated.id, message: MESSAGES.VISITOR.UPDATED_SUCCESS };
+  }
+}

--- a/src/modules/visitor/features/get_visitors/data/get_visitors.repository.ts
+++ b/src/modules/visitor/features/get_visitors/data/get_visitors.repository.ts
@@ -1,0 +1,91 @@
+// src/modules/visitor/features/get_visitors/data/get_visitors.repository.ts
+import prisma from "../../../../../config/prisma_client";
+
+export type FindParams = {
+  skip: number;
+  take: number;
+  search?: string; // first_name/last_name/company
+  employee_id?: string;
+  space_id?: string;
+  date_from?: Date;
+  date_to?: Date;
+};
+
+export class GetVisitorsRepository {
+  findById(id: string) {
+    return prisma.visitors.findUnique({
+      where: { id },
+      include: {
+        employee: {
+          select: {
+            employee_id: true,
+            company: { select: { id: true, name: true } },
+            work_area: { select: { id: true, name: true } },
+            user: { select: { id: true, first_name: true, last_name: true } },
+          },
+        },
+        space: { select: { id: true, name: true } },
+      },
+    });
+  }
+
+  findMany(p: FindParams) {
+    const { skip, take, search, employee_id, space_id, date_from, date_to } = p;
+    return prisma.visitors.findMany({
+      skip,
+      take,
+      where: {
+        ...(employee_id ? { employee_id } : {}),
+        ...(space_id ? { space_id } : {}),
+        ...(search
+          ? {
+              OR: [
+                { first_name: { contains: search, mode: "insensitive" } },
+                { last_name: { contains: search, mode: "insensitive" } },
+                { company: { contains: search, mode: "insensitive" } },
+              ],
+            }
+          : {}),
+        ...(date_from || date_to
+          ? {
+              entry_time: {
+                ...(date_from ? { gte: date_from } : {}),
+                ...(date_to ? { lte: date_to } : {}),
+              },
+            }
+          : {}),
+      },
+      orderBy: { created_at: "desc" },
+      include: {
+        space: { select: { id: true, name: true } },
+      },
+    });
+  }
+
+  count(p: Omit<FindParams, "skip" | "take">) {
+    const { search, employee_id, space_id, date_from, date_to } = p;
+    return prisma.visitors.count({
+      where: {
+        ...(employee_id ? { employee_id } : {}),
+        ...(space_id ? { space_id } : {}),
+        ...(search
+          ? {
+              OR: [
+                { first_name: { contains: search, mode: "insensitive" } },
+                { last_name: { contains: search, mode: "insensitive" } },
+                { company: { contains: search, mode: "insensitive" } },
+              ],
+            }
+          : {}),
+        ...(date_from || date_to
+          ? {
+              entry_time: {
+                ...(date_from ? { gte: date_from } : {}),
+                ...(date_to ? { lte: date_to } : {}),
+              },
+            }
+          : {}),
+      },
+    });
+  }
+}

--- a/src/modules/visitor/features/get_visitors/domain/get_visitors.schema.ts
+++ b/src/modules/visitor/features/get_visitors/domain/get_visitors.schema.ts
@@ -1,0 +1,41 @@
+// src/modules/visitor/features/get_visitors/domain/get_visitors.schema.ts
+import { z } from "zod";
+
+const toNumber = (v: unknown, def: number) => {
+  const n = Number(v);
+  return Number.isFinite(n) && n > 0 ? n : def;
+};
+
+export const GetVisitorsQuerySchema = z
+  .object({
+    page: z
+      .preprocess((v) => toNumber(v, 1), z.number().int().positive())
+      .default(1),
+    limit: z
+      .preprocess((v) => {
+        const n = toNumber(v, 10);
+        return Math.min(n, 100);
+      }, z.number().int().positive())
+      .default(10),
+    search: z
+      .string()
+      .transform((s) => s?.trim() || "")
+      .optional(),
+    employee_id: z.string().uuid().optional(),
+    space_id: z.string().uuid().optional(),
+    date_from: z.string().datetime().optional(),
+    date_to: z.string().datetime().optional(),
+  })
+  .refine(
+    (v) => {
+      if (v.date_from && v.date_to) {
+        return new Date(v.date_to).getTime() >= new Date(v.date_from).getTime();
+      }
+      return true;
+    },
+    { message: "date_to must be >= date_from", path: ["date_to"] },
+  );
+
+export const GetVisitorParamSchema = z.object({
+  id: z.string().uuid(),
+});

--- a/src/modules/visitor/features/get_visitors/presentation/get_visitors.controller.ts
+++ b/src/modules/visitor/features/get_visitors/presentation/get_visitors.controller.ts
@@ -1,0 +1,44 @@
+// src/modules/visitor/features/get_visitors/presentation/get_visitors.controller.ts
+import { Response } from "express";
+import { buildHttpResponse } from "../../../../../utils/build_http_response";
+import { HttpStatusCodes } from "../../../../../constants/http_status_codes";
+import { GetVisitorsService } from "./get_visitors.service";
+import {
+  GetVisitorsQuerySchema,
+  GetVisitorParamSchema,
+} from "../domain/get_visitors.schema";
+import type { AuthenticatedRequest } from "../../../../../middlewares/authenticate_token";
+
+export class GetVisitorsController {
+  constructor(private readonly service = new GetVisitorsService()) {}
+
+  async getAll(req: AuthenticatedRequest, res: Response) {
+    const query = GetVisitorsQuerySchema.parse(req.query);
+    const data = await this.service.getAll(query);
+    return res
+      .status(HttpStatusCodes.OK.code)
+      .json(
+        buildHttpResponse(
+          HttpStatusCodes.OK.code,
+          "Visitors list",
+          req.path,
+          data,
+        ),
+      );
+  }
+
+  async getOne(req: AuthenticatedRequest, res: Response) {
+    const { id } = GetVisitorParamSchema.parse(req.params);
+    const data = await this.service.getOne(id);
+    return res
+      .status(HttpStatusCodes.OK.code)
+      .json(
+        buildHttpResponse(
+          HttpStatusCodes.OK.code,
+          "Visitor detail",
+          req.path,
+          data,
+        ),
+      );
+  }
+}

--- a/src/modules/visitor/features/get_visitors/presentation/get_visitors.routes.ts
+++ b/src/modules/visitor/features/get_visitors/presentation/get_visitors.routes.ts
@@ -1,0 +1,85 @@
+// src/modules/visitor/features/get_visitors/presentation/get_visitors.routes.ts
+import { Router } from "express";
+import { asyncHandler } from "../../../../../middlewares/async_handler";
+import { GetVisitorsController } from "./get_visitors.controller";
+
+const router = Router();
+const controller = new GetVisitorsController();
+/**
+ * @openapi
+ * /api/v1/visitors:
+ *   get:
+ *     tags: [Visitor]
+ *     summary: Listar visitantes
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: query
+ *         name: page
+ *         schema:
+ *           type: integer
+ *           example: 1
+ *       - in: query
+ *         name: limit
+ *         schema:
+ *           type: integer
+ *           example: 10
+ *           maximum: 100
+ *       - in: query
+ *         name: search
+ *         schema:
+ *           type: string
+ *           example: "Alicorp"
+ *       - in: query
+ *         name: employee_id
+ *         schema:
+ *           type: string
+ *           format: uuid
+ *       - in: query
+ *         name: space_id
+ *         schema:
+ *           type: string
+ *           format: uuid
+ *       - in: query
+ *         name: date_from
+ *         schema:
+ *           type: string
+ *           format: date-time
+ *           example: "2025-08-01T00:00:00.000Z"
+ *       - in: query
+ *         name: date_to
+ *         schema:
+ *           type: string
+ *           format: date-time
+ *           example: "2025-08-31T23:59:59.999Z"
+ *     responses:
+ *       200:
+ *         description: Lista paginada de visitantes
+ *       400:
+ *         description: Parámetros inválidos
+ */
+router.get("/", asyncHandler(controller.getAll.bind(controller)));
+/**
+ * @openapi
+ * /api/v1/visitors/{id}:
+ *   get:
+ *     tags: [Visitor]
+ *     summary: Detalle de un visitante
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         schema:
+ *           type: string
+ *           format: uuid
+ *     responses:
+ *       200:
+ *         description: Visitante encontrado
+ *       404:
+ *         description: Visitante no encontrado
+ */
+router.get("/:id", asyncHandler(controller.getOne.bind(controller)));
+
+export { router as getVisitorsRoutes };

--- a/src/modules/visitor/features/get_visitors/presentation/get_visitors.service.ts
+++ b/src/modules/visitor/features/get_visitors/presentation/get_visitors.service.ts
@@ -1,0 +1,51 @@
+// src/modules/visitor/features/get_visitors/presentation/get_visitors.service.ts
+import { GetVisitorsRepository } from "../data/get_visitors.repository";
+import { AppError } from "../../../../../utils/errors";
+import { HttpStatusCodes } from "../../../../../constants/http_status_codes";
+import { MESSAGES } from "../../../../../constants/messages";
+import type { z } from "zod";
+import { GetVisitorsQuerySchema } from "../domain/get_visitors.schema";
+
+export class GetVisitorsService {
+  constructor(private readonly repo = new GetVisitorsRepository()) {}
+
+  async getOne(id: string) {
+    const v = await this.repo.findById(id);
+    if (!v)
+      throw new AppError(
+        MESSAGES.VISITOR.NOT_FOUND,
+        HttpStatusCodes.NOT_FOUND.code,
+      );
+    return v;
+  }
+
+  async getAll(query: z.infer<typeof GetVisitorsQuerySchema>) {
+    const { page, limit, search, employee_id, space_id, date_from, date_to } =
+      query;
+    const skip = (page - 1) * limit;
+
+    const [items, total] = await Promise.all([
+      this.repo.findMany({
+        skip,
+        take: limit,
+        search,
+        employee_id,
+        space_id,
+        date_from: date_from ? new Date(date_from) : undefined,
+        date_to: date_to ? new Date(date_to) : undefined,
+      }),
+      this.repo.count({
+        search,
+        employee_id,
+        space_id,
+        date_from: date_from ? new Date(date_from) : undefined,
+        date_to: date_to ? new Date(date_to) : undefined,
+      }),
+    ]);
+
+    return {
+      items,
+      meta: { page, limit, total, totalPages: Math.ceil(total / limit) || 1 },
+    };
+  }
+}

--- a/src/modules/visitor/features/lookup_visitor/index.ts
+++ b/src/modules/visitor/features/lookup_visitor/index.ts
@@ -1,0 +1,1 @@
+import { LookupVisitorController } from "./presentation/lookup.controller";

--- a/src/modules/visitor/features/lookup_visitor/presentation/lookup.controller.ts
+++ b/src/modules/visitor/features/lookup_visitor/presentation/lookup.controller.ts
@@ -1,0 +1,89 @@
+// src/modules/visitor/features/lookup_visitor/presentation/lookup.controller.ts
+import { Response } from "express";
+import { buildHttpResponse } from "../../../../../utils/build_http_response";
+import { HttpStatusCodes } from "../../../../../constants/http_status_codes";
+import { AuthenticatedRequest } from "../../../../../middlewares/authenticate_token";
+import { z } from "zod";
+import {
+  DecolectaClient,
+  normalizeReniecToVisitor,
+  normalizeSunatToVisitor,
+} from "../../../../../shared/decolecta/decolecta.client";
+import { MESSAGES } from "../../../../../constants/messages";
+
+const QuerySchema = z
+  .object({
+    dni: z.string().length(8).optional(),
+    ruc: z.string().length(11).optional(),
+  })
+  .refine((v) => v.dni || v.ruc, { message: "dni or ruc required" });
+
+export class LookupVisitorController {
+  private client = new DecolectaClient();
+
+  async handle(req: AuthenticatedRequest, res: Response) {
+    const { dni, ruc } = QuerySchema.parse(req.query);
+
+    if (dni) {
+      const data = await this.client.lookupByDni(dni);
+      if (!data) {
+        return res
+          .status(HttpStatusCodes.NOT_FOUND.code)
+          .json(
+            buildHttpResponse(
+              HttpStatusCodes.NOT_FOUND.code,
+              MESSAGES.VISITOR.LOOKUP_NOT_FOUND,
+              req.path,
+            ),
+          );
+      }
+      const payload = normalizeReniecToVisitor(data);
+      return res
+        .status(HttpStatusCodes.OK.code)
+        .json(
+          buildHttpResponse(
+            HttpStatusCodes.OK.code,
+            "Lookup ok",
+            req.path,
+            payload,
+          ),
+        );
+    }
+
+    if (ruc) {
+      const data = await this.client.lookupByRuc(ruc);
+      if (!data) {
+        return res
+          .status(HttpStatusCodes.NOT_FOUND.code)
+          .json(
+            buildHttpResponse(
+              HttpStatusCodes.NOT_FOUND.code,
+              MESSAGES.VISITOR.LOOKUP_NOT_FOUND,
+              req.path,
+            ),
+          );
+      }
+      const payload = normalizeSunatToVisitor(data, ruc);
+      return res
+        .status(HttpStatusCodes.OK.code)
+        .json(
+          buildHttpResponse(
+            HttpStatusCodes.OK.code,
+            "Lookup ok",
+            req.path,
+            payload,
+          ),
+        );
+    }
+
+    return res
+      .status(HttpStatusCodes.BAD_REQUEST.code)
+      .json(
+        buildHttpResponse(
+          HttpStatusCodes.BAD_REQUEST.code,
+          "dni or ruc required",
+          req.path,
+        ),
+      );
+  }
+}

--- a/src/modules/visitor/index.ts
+++ b/src/modules/visitor/index.ts
@@ -1,0 +1,25 @@
+import { Router } from "express";
+
+import { createAndLookupVisitorRoutes } from "./features/create_visitor/service/create_visitor.routes";
+import { getVisitorsRoutes } from "./features/get_visitors/presentation/get_visitors.routes";
+import { editVisitorRoutes } from "./features/edit_visitor/presentation/edit_visitor.routes";
+import { deleteVisitorRoutes } from "./features/delete_visitor/presentation/delete_visitor.routes";
+
+const visitorRouter = Router();
+
+visitorRouter.use("/", createAndLookupVisitorRoutes);
+visitorRouter.use("/", getVisitorsRoutes);
+visitorRouter.use("/", editVisitorRoutes);
+visitorRouter.use("/", deleteVisitorRoutes);
+/**
+ * MATCHES:
+ * POST /api/v1/visitors → Crear visitante manual
+ * GET /api/v1/visitors/lookup?dni=12345678 → Lookup RENIEC
+ * GET /api/v1/visitors/lookup?ruc=20123456789 → Lookup SUNAT
+ * GET /api/v1/visitors → Listar visitantes (paginado + filtros)
+ * GET /api/v1/visitors/:id → Detalle de visitante
+ * PUT /api/v1/visitors/:id → Editar visitante (checkout / update)
+ * DELETE /api/v1/visitors/:id → Eliminar visitante
+ */
+
+export default visitorRouter;

--- a/src/modules/workarea/features/create_workarea/data/create_workarea.repository.ts
+++ b/src/modules/workarea/features/create_workarea/data/create_workarea.repository.ts
@@ -5,7 +5,7 @@ import { WorkAreaEntity } from "../../../entities/workarea.entity";
 
 export class CreateWorkAreaRepository {
   async execute(data: CreateWorkAreaDTO): Promise<WorkAreaEntity> {
-    const workarea = await prisma.workArea.create({
+    const workarea = await prisma.work_areas.create({
       data: {
         name: data.name,
         description: data.description || null,
@@ -24,7 +24,7 @@ export class CreateWorkAreaRepository {
   }
 
   async checkIfNameExists(name: string): Promise<boolean> {
-    const existingWorkArea = await prisma.workArea.findFirst({
+    const existingWorkArea = await prisma.work_areas.findFirst({
       where: {
         name: {
           equals: name,

--- a/src/modules/workarea/features/delete_workarea/data/delete_workarea.repository.ts
+++ b/src/modules/workarea/features/delete_workarea/data/delete_workarea.repository.ts
@@ -4,13 +4,13 @@ import { WorkAreaEntity } from "../../../entities/workarea.entity";
 
 export class DeleteWorkAreaRepository {
   async execute(id: string): Promise<void> {
-    await prisma.workArea.delete({
+    await prisma.work_areas.delete({
       where: { id },
     });
   }
 
   async findById(id: string): Promise<WorkAreaEntity | null> {
-    const workarea = await prisma.workArea.findUnique({
+    const workarea = await prisma.work_areas.findUnique({
       where: { id },
     });
 

--- a/src/modules/workarea/features/list_workareas/data/list_workareas.repository.ts
+++ b/src/modules/workarea/features/list_workareas/data/list_workareas.repository.ts
@@ -4,7 +4,7 @@ import prisma from "../../../../../config/prisma_client";
 
 export class ListWorkAreasRepository {
   async execute(): Promise<WorkAreaEntity[]> {
-    const workareas = await prisma.workArea.findMany({
+    const workareas = await prisma.work_areas.findMany({
       orderBy: {
         created_at: "desc",
       },

--- a/src/modules/workarea/features/update_workarea/data/update_workarea.repository.ts
+++ b/src/modules/workarea/features/update_workarea/data/update_workarea.repository.ts
@@ -5,7 +5,7 @@ import { WorkAreaEntity } from "../../../entities/workarea.entity";
 
 export class UpdateWorkAreaRepository {
   async execute(id: string, data: UpdateWorkAreaDTO): Promise<WorkAreaEntity> {
-    const workarea = await prisma.workArea.update({
+    const workarea = await prisma.work_areas.update({
       where: { id },
       data: {
         ...(data.name && { name: data.name }),
@@ -27,7 +27,7 @@ export class UpdateWorkAreaRepository {
   }
 
   async findById(id: string): Promise<WorkAreaEntity | null> {
-    const workarea = await prisma.workArea.findUnique({
+    const workarea = await prisma.work_areas.findUnique({
       where: { id },
     });
 
@@ -45,9 +45,9 @@ export class UpdateWorkAreaRepository {
 
   async checkIfNameExistsExcludingId(
     name: string,
-    excludeId: string
+    excludeId: string,
   ): Promise<boolean> {
-    const existingWorkArea = await prisma.workArea.findFirst({
+    const existingWorkArea = await prisma.work_areas.findFirst({
       where: {
         name: {
           equals: name,

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -18,10 +18,11 @@ import { newsletterRouter } from "./modules/newsletter";
 import productRouter, { productBrandRouter } from "./modules/product";
 import { chatbotwhatsapp } from "./modules/chatbot/presentation/send_message.routes";
 
-// Nuevos módulos añadidos
 import { seedRouter } from "./modules/seed/presentation/seed.routes";
 import { workareaRouter } from "./modules/workarea";
 import { companyRouter } from "./modules/company";
+
+import visitorRouter from "./modules/visitor";
 
 const router = Router();
 const API_VERSION = "/api/v1";
@@ -51,9 +52,10 @@ router.use(`${API_VERSION}/product-brands`, productBrandRouter);
 
 router.use(`${API_VERSION}/chatbotwhatsapp`, chatbotwhatsapp);
 
-// Nuevas rutas
 router.use(`${API_VERSION}/seed`, seedRouter);
 router.use(`${API_VERSION}/`, workareaRouter);
 router.use(`${API_VERSION}/`, companyRouter);
+
+router.use(`${API_VERSION}/visitors`, visitorRouter);
 
 export default router;

--- a/src/shared/decolecta/decolecta.client.ts
+++ b/src/shared/decolecta/decolecta.client.ts
@@ -1,0 +1,116 @@
+import { DECOLECTA_API_KEY, DECOLECTA_BASE_URL } from "../../config/env";
+import { AppError } from "../../utils/errors";
+import { HttpStatusCodes } from "../../constants/http_status_codes";
+import { z } from "zod";
+
+/** ─────────────────────────────────────────────────────────
+ *  Schemas de respuesta (según doc)
+ *  ───────────────────────────────────────────────────────── */
+const ReniecResponseSchema = z.object({
+  first_name: z.string(),
+  first_last_name: z.string(),
+  second_last_name: z.string(),
+  full_name: z.string(),
+  document_number: z.string(),
+});
+
+type ReniecResponse = z.infer<typeof ReniecResponseSchema>;
+
+const SunatRucResponseSchema = z
+  .object({
+    // Ajusta si tu doc de SUNAT trae más/menos campos.
+    ruc: z.string().optional(),
+    razonSocial: z.string().optional(),
+    // campos adicionales ignorados si llegan
+  })
+  .passthrough();
+
+type SunatRucResponse = z.infer<typeof SunatRucResponseSchema>;
+
+/** ─────────────────────────────────────────────────────────
+ *  Cliente DeColecta
+ *  ───────────────────────────────────────────────────────── */
+export class DecolectaClient {
+  private base = (DECOLECTA_BASE_URL ?? "https://api.decolecta.com").replace(
+    /\/+$/,
+    "",
+  );
+
+  private headers() {
+    if (!DECOLECTA_API_KEY) {
+      throw new AppError(
+        "DECOLECTA_API_KEY not configured",
+        HttpStatusCodes.INTERNAL_SERVER_ERROR.code,
+      );
+    }
+    return {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${DECOLECTA_API_KEY}`,
+    };
+  }
+
+  /** GET /v1/reniec/dni?numero=XXXXXXXX
+   *  Retorna null si 404; lanza AppError para otros estados.
+   */
+  async lookupByDni(dni: string) {
+    const url = `${this.base}/v1/reniec/dni?numero=${encodeURIComponent(dni)}`;
+    const res = await fetch(url, { headers: this.headers() });
+
+    if (res.status === 404) return null;
+    if (!res.ok) {
+      const text = await res.text().catch(() => "");
+      throw new AppError(
+        `DeColecta RENIEC error: ${res.status} ${res.statusText}${text ? ` – ${text}` : ""}`,
+        HttpStatusCodes.BAD_GATEWAY.code,
+      );
+    }
+
+    const json = (await res.json()) as unknown;
+    return ReniecResponseSchema.parse(json);
+  }
+
+  /** GET /v1/sunat/ruc?numero=XXXXXXXXXXX
+   *  Retorna null si 404; lanza AppError para otros estados.
+   */
+  async lookupByRuc(ruc: string) {
+    const url = `${this.base}/v1/sunat/ruc?numero=${encodeURIComponent(ruc)}`;
+    const res = await fetch(url, { headers: this.headers() });
+
+    if (res.status === 404) return null;
+    if (!res.ok) {
+      const text = await res.text().catch(() => "");
+      throw new AppError(
+        `DeColecta SUNAT error: ${res.status} ${res.statusText}${text ? ` – ${text}` : ""}`,
+        HttpStatusCodes.BAD_GATEWAY.code,
+      );
+    }
+
+    const json = (await res.json()) as unknown;
+    return SunatRucResponseSchema.parse(json);
+  }
+}
+
+/** ─────────────────────────────────────────────────────────
+ *  Normalizadores opcionales para tu capa de presentación
+ *  ───────────────────────────────────────────────────────── */
+export function normalizeReniecToVisitor(dto: ReniecResponse) {
+  const firstName = dto.first_name?.trim() ?? "";
+  const lastName = [dto.first_last_name, dto.second_last_name]
+    .filter(Boolean)
+    .map((s) => s.trim())
+    .join(" ");
+
+  return {
+    first_name: firstName,
+    last_name: lastName,
+    full_name: dto.full_name,
+    dni: dto.document_number,
+  };
+}
+
+export function normalizeSunatToVisitor(dto: SunatRucResponse, ruc: string) {
+  return {
+    ruc,
+    company: dto.razonSocial ?? "",
+  };
+}


### PR DESCRIPTION
---

## 👥 Visitors – Full CRUD with DeColecta Lookup

### ✅ 1. Lookup (via DeColecta)
- `GET /visitors/lookup?dni=...`
- `GET /visitors/lookup?ruc=...`
- Normalizers:
  - `normalizeReniecToVisitor`
  - `normalizeSunatToVisitor`
- Integrated via `shared/decolecta/DeColectaClient`

### ✅ 2. Create Visitor
- Manual or prefilled with lookup data
- Validates:
  - Host (employee) exists
  - Space exists
- Admin-only (option to expand to staff)
- Required fields: dni/ruc, first_name, last_name, company, phone, email, entry_time, exit_time

### ✅ 3. Get Visitors
- Pagination and filters:
  - `page`, `limit`
  - `search`, `employee_id`, `space_id`, `date_from`, `date_to`
- Detail via `GET /visitors/:id`

### ✅ 4. Edit Visitor
- Editable: phone, email, company, exit_time, space_id
- Validations:
  - Cannot overwrite exit_time if already set
  - space_id must exist
- Admin-only

### ✅ 5. Delete Visitor
- Admin-only
- Deletes by ID

### 📂 Visitor Endpoints
POST   /api/v1/visitors
GET    /api/v1/visitors/lookup
GET    /api/v1/visitors
GET    /api/v1/visitors/:id
PUT    /api/v1/visitors/:id
DELETE /api/v1/visitors/:id