### PR TITLE
chore(api): :twisted_rightwards_arrows: reorganize routes and implemention pages

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -143,7 +143,8 @@ model users {
   reservations         reservation[]         @relation("user_reservations") // Reservas realizadas por el usuario
   payment_transactions payment_transaction[] @relation("user_payments")
   articles             articles[]            @relation("user_articles")
-  client_details       client_details?
+
+  hosted_visitors visitors[] @relation("visitor_host")
 
   @@map("users") // (opcional; ya está en snake_case)
 }
@@ -189,7 +190,6 @@ model companies {
 
   employees employee_details[]
 
-  clients  client_details[]
   visitors visitors[]
 
   @@map("companies")
@@ -420,39 +420,28 @@ model product_brand {
 
 model visitors {
   id         String    @id @default(uuid()) // Identificador único
-  dni        String?   @unique // DNI (si es persona natural)
-  ruc        String?   @unique // RUC (si es empresa/independiente)
+  dni        String?   // DNI (si es persona natural)
+  ruc        String?   // RUC (si es empresa/independiente)
   first_name String // Nombre
   last_name  String // Apellido
   phone      String? // Teléfono
   email      String? // Correo
-  client_id  String // A quién visita (FK a client_details)
+  host_user_id String // A quién visita (FK a client_details)
   company_id String? // Compañía del cliente (redundante pero útil p/queries)
-  space_id   String // Espacio visitado (FK a space)
+  space_id   String // Espacio visitado (FK a space)WWWSW
   entry_time DateTime // Hora de entrada
   exit_time  DateTime? // Hora de salida (opcional)
   created_at DateTime  @default(now())
 
-  client                      client_details    @relation(fields: [client_id], references: [client_id], onDelete: Cascade)
+  host         users      @relation("visitor_host", fields: [host_user_id], references: [id], onDelete: Cascade)
+
   company                     companies?        @relation(fields: [company_id], references: [id], onDelete: SetNull)
   space                       space             @relation(fields: [space_id], references: [id], onDelete: Cascade)
   employee_details            employee_details? @relation(fields: [employee_detailsEmployee_id], references: [employee_id])
   employee_detailsEmployee_id String?
 
-  @@index([client_id, created_at])
+  @@index([host_user_id, created_at]) 
   @@index([space_id, created_at])
   @@index([company_id])
   @@map("visitors")
-}
-
-model client_details {
-  client_id String @id
-  user      users  @relation(fields: [client_id], references: [id], onDelete: Cascade)
-
-  company_id String?
-  company    companies? @relation(fields: [company_id], references: [id], onDelete: SetNull)
-  visitors   visitors[]
-
-  @@index([company_id])
-  @@map("client_details")
 }

--- a/src/constants/messages/visitor/index.ts
+++ b/src/constants/messages/visitor/index.ts
@@ -4,6 +4,7 @@ export const VISITOR_MESSAGES = {
   DELETED_SUCCESS: "El visitante se ha eliminado correctamente",
 
   NOT_FOUND: "El visitante no existe",
+  COMPANY_NOT_FOUND: "La compañia no existe",
   FORBIDDEN: "No tienes permiso para realizar esta acción",
 
   HOST_NOT_FOUND: "El anfitrión (empleado) no existe",

--- a/src/modules/product/features/brand/get_brand/data/get_brand.repository.ts
+++ b/src/modules/product/features/brand/get_brand/data/get_brand.repository.ts
@@ -1,34 +1,17 @@
 // src/modules/product/features/brand/get_brand/data/get_brand.repository.ts
 import prisma from "../../../../../../config/prisma_client";
 
-export type FindAllParams = {
-  skip: number;
-  take: number;
-  search?: string;
-};
-
 export class GetBrandRepository {
   findById(id: string) {
     return prisma.product_brand.findUnique({ where: { id } });
   }
 
-  findMany(params: FindAllParams) {
-    const { skip, take, search } = params;
+  findMany(search?: string) {
     return prisma.product_brand.findMany({
-      skip,
-      take,
       where: search
         ? { name: { contains: search, mode: "insensitive" } }
         : undefined,
       orderBy: { created_at: "desc" },
-    });
-  }
-
-  count(search?: string) {
-    return prisma.product_brand.count({
-      where: search
-        ? { name: { contains: search, mode: "insensitive" } }
-        : undefined,
     });
   }
 }

--- a/src/modules/product/features/brand/get_brand/domain/get_brand.schema.ts
+++ b/src/modules/product/features/brand/get_brand/domain/get_brand.schema.ts
@@ -2,30 +2,6 @@
 import { z } from "zod";
 
 export const GetBrandQuerySchema = z.object({
-  page: z
-    .preprocess(
-      (v) => (v === undefined ? undefined : Number(v)),
-      z
-        .number({
-          invalid_type_error: "La página debe ser un número",
-        })
-        .int("La página debe ser un número entero")
-        .positive("La página debe ser mayor a 0")
-    )
-    .default(1),
-
-  limit: z
-    .preprocess(
-      (v) => (v === undefined ? undefined : Number(v)),
-      z
-        .number({
-          invalid_type_error: "El límite debe ser un número",
-        })
-        .int("El límite debe ser un número entero")
-        .positive("El límite debe ser mayor a 0")
-    )
-    .default(10),
-
   search: z
     .string({
       invalid_type_error: "El parámetro de búsqueda debe ser texto",

--- a/src/modules/product/features/brand/get_brand/presentation/get_brand.controller.ts
+++ b/src/modules/product/features/brand/get_brand/presentation/get_brand.controller.ts
@@ -21,8 +21,8 @@ export class GetBrandController {
           HttpStatusCodes.OK.code,
           "Brand detail",
           req.path,
-          data,
-        ),
+          data
+        )
       );
   }
 
@@ -34,12 +34,7 @@ export class GetBrandController {
     return res
       .status(HttpStatusCodes.OK.code)
       .json(
-        buildHttpResponse(
-          HttpStatusCodes.OK.code,
-          "Brand list",
-          req.path,
-          data,
-        ),
+        buildHttpResponse(HttpStatusCodes.OK.code, "Brand list", req.path, data)
       );
   }
 }

--- a/src/modules/product/features/brand/get_brand/presentation/get_brand.routes.ts
+++ b/src/modules/product/features/brand/get_brand/presentation/get_brand.routes.ts
@@ -8,18 +8,12 @@ const controller = new GetBrandController();
 
 /**
  * @openapi
- * /api/v1/product-brands:
+ * /api/v1/product/brands:
  *   get:
  *     tags:
  *       - ProductBrand
  *     summary: Get all brands
  *     parameters:
- *       - in: query
- *         name: page
- *         schema: { type: integer, example: 1 }
- *       - in: query
- *         name: limit
- *         schema: { type: integer, example: 10 }
  *       - in: query
  *         name: search
  *         schema: { type: string, example: "Lenovo" }
@@ -31,7 +25,7 @@ router.get("/", asyncHandler(controller.getAll.bind(controller)));
 
 /**
  * @openapi
- * /api/v1/product-brands/{id}:
+ * /api/v1/product/brands/{id}:
  *   get:
  *     tags:
  *       - ProductBrand

--- a/src/modules/product/features/brand/get_brand/presentation/get_brand.service.ts
+++ b/src/modules/product/features/brand/get_brand/presentation/get_brand.service.ts
@@ -13,30 +13,15 @@ export class GetBrandService {
     if (!brand) {
       throw new AppError(
         MESSAGES.PRODUCT.NOT_FOUND,
-        HttpStatusCodes.NOT_FOUND.code,
+        HttpStatusCodes.NOT_FOUND.code
       );
     }
     return brand;
   }
 
   async getAll(query: GetBrandQueryDTO) {
-    const { page, limit, search } = query;
-    const skip = (page - 1) * limit;
-
-    // Ejecutamos en paralelo porque NO dependen entre sí
-    const [items, total] = await Promise.all([
-      this.repo.findMany({ skip, take: limit, search }),
-      this.repo.count(search),
-    ]);
-
-    return {
-      items,
-      meta: {
-        page,
-        limit,
-        total,
-        totalPages: Math.ceil(total / limit) || 1,
-      },
-    };
+    const { search } = query;
+    return this.repo.findMany(search);
   }
 }
+  

--- a/src/modules/product/features/crud/get_products/data/get_products.repository.ts
+++ b/src/modules/product/features/crud/get_products/data/get_products.repository.ts
@@ -13,9 +13,7 @@ export class GetProductsRepository {
   findById(id: string) {
     return prisma.products.findUnique({
       where: { id },
-      include: {
-        brand: { select: { id: true, name: true } },
-      },
+      include: { brand: { select: { id: true, name: true } } },
     });
   }
 
@@ -32,9 +30,7 @@ export class GetProductsRepository {
           ? { brand: { name: { contains: brandName, mode: "insensitive" } } }
           : {}),
       },
-      include: {
-        brand: { select: { id: true, name: true } },
-      },
+      include: { brand: { select: { id: true, name: true } } },
       orderBy: { name: "asc" },
     });
   }

--- a/src/modules/product/features/crud/get_products/domain/get_products.schema.ts
+++ b/src/modules/product/features/crud/get_products/domain/get_products.schema.ts
@@ -1,50 +1,17 @@
+// src/modules/product/features/get_products/domain/get_products.schema.ts
 import { z } from "zod";
 
 export const GetProductsQuerySchema = z.object({
-  page: z
-    .preprocess(
-      (v) => (v === undefined ? 1 : Number(v)),
-      z
-        .number({
-          invalid_type_error: "La página debe ser un número",
-        })
-        .int("La página debe ser un número entero")
-        .positive("La página debe ser mayor a 0")
-    )
-    .default(1),
-
-  limit: z
-    .preprocess(
-      (v) => (v === undefined ? 10 : Number(v)),
-      z
-        .number({
-          invalid_type_error: "El límite debe ser un número",
-        })
-        .int("El límite debe ser un número entero")
-        .positive("El límite debe ser mayor a 0")
-    )
-    .default(10),
-
-  search: z
-    .string({
-      invalid_type_error: "El parámetro de búsqueda debe ser texto",
-    })
-    .trim()
-    .optional(),
-
+  page: z.string().optional(),
+  limit: z.string().optional(),
+  search: z.string().trim().optional(),
   brand_id: z
     .string({
       invalid_type_error: "El ID de la marca debe ser una cadena (UUID)",
     })
     .uuid("El ID de la marca debe ser un UUID válido")
     .optional(),
-
-  brand_name: z
-    .string({
-      invalid_type_error: "El nombre de la marca debe ser una cadena de texto",
-    })
-    .trim()
-    .optional(),
+  brand_name: z.string().trim().optional(),
 });
 
 export const GetProductParamSchema = z.object({

--- a/src/modules/product/features/crud/get_products/presentation/get_products.routes.ts
+++ b/src/modules/product/features/crud/get_products/presentation/get_products.routes.ts
@@ -13,25 +13,74 @@ const controller = new GetProductsController();
  *     tags:
  *       - Product
  *     summary: Listar productos
+ *     description: |
+ *       Devuelve un listado de productos con soporte de **paginación** y filtros opcionales.
  *     parameters:
  *       - in: query
  *         name: page
- *         schema: { type: integer, example: 1 }
+ *         schema: { type: integer, example: 1, minimum: 1 }
+ *         description: Número de página (por defecto 1)
  *       - in: query
  *         name: limit
- *         schema: { type: integer, example: 10 }
+ *         schema: { type: integer, example: 10, minimum: 1, maximum: 100 }
+ *         description: Cantidad de registros por página (por defecto 10, máximo 100)
  *       - in: query
  *         name: search
  *         schema: { type: string, example: "laptop" }
+ *         description: Texto a buscar en el nombre del producto
  *       - in: query
  *         name: brand_id
- *         schema: { type: string, format: uuid }
+ *         schema: { type: string, format: uuid, example: "550e8400-e29b-41d4-a716-446655440000" }
+ *         description: Filtro por ID de marca (UUID)
  *       - in: query
  *         name: brand_name
  *         schema: { type: string, example: "Lenovo" }
+ *         description: Filtro por nombre de marca
  *     responses:
  *       200:
  *         description: Lista paginada de productos
+ *         content:
+ *           application/json:
+ *             examples:
+ *               normal:
+ *                 summary: Listado normal (sin parámetros)
+ *                 value:
+ *                   status: 200
+ *                   message: "Lista de productos"
+ *                   path: "/api/v1/products"
+ *                   data:
+ *                     items:
+ *                       - id: "1f4e2c10-9a93-44cb-8d25-b6b6fbcf1141"
+ *                         name: "Laptop X"
+ *                         brand: { id: "11111111-1111-1111-1111-111111111111", name: "Lenovo" }
+ *                       - id: "2c5f1a12-0c14-45bb-9dc5-52f1d5e2a9a9"
+ *                         name: "Mouse Gamer"
+ *                         brand: { id: "22222222-2222-2222-2222-222222222222", name: "Logitech" }
+ *                     meta:
+ *                       total: 25
+ *                       page: 1
+ *                       limit: 10
+ *                       totalPages: 3
+ *                       hasNextPage: true
+ *                       hasPrevPage: false
+ *               paginado:
+ *                 summary: Listado paginado con filtros
+ *                 value:
+ *                   status: 200
+ *                   message: "Lista de productos"
+ *                   path: "/api/v1/products"
+ *                   data:
+ *                     items:
+ *                       - id: "3f6e1d13-7a82-4dbb-9d12-15e3d65f7e21"
+ *                         name: "Laptop Gamer Y"
+ *                         brand: { id: "11111111-1111-1111-1111-111111111111", name: "Lenovo" }
+ *                     meta:
+ *                       total: 5
+ *                       page: 2
+ *                       limit: 2
+ *                       totalPages: 3
+ *                       hasNextPage: true
+ *                       hasPrevPage: true
  */
 router.get("/", asyncHandler(controller.getAll.bind(controller)));
 
@@ -50,6 +99,16 @@ router.get("/", asyncHandler(controller.getAll.bind(controller)));
  *     responses:
  *       200:
  *         description: Detalle de producto
+ *         content:
+ *           application/json:
+ *             example:
+ *               status: 200
+ *               message: "Detalle del producto"
+ *               path: "/api/v1/products/1f4e2c10-9a93-44cb-8d25-b6b6fbcf1141"
+ *               data:
+ *                 id: "1f4e2c10-9a93-44cb-8d25-b6b6fbcf1141"
+ *                 name: "Laptop X"
+ *                 brand: { id: "11111111-1111-1111-1111-111111111111", name: "Lenovo" }
  *       404:
  *         description: Producto no encontrado
  */

--- a/src/modules/product/index.ts
+++ b/src/modules/product/index.ts
@@ -1,7 +1,7 @@
 // src/modules/product/index.ts
 import { Router } from "express";
 
-//PRODUCT CRUD ( /api/v1/products )
+// PRODUCT CRUD ( /api/v1/products )
 import { createProductRoutes } from "./features/crud/create_product";
 import { editProductRoutes } from "./features/crud/edit_product";
 import { deleteProductRoutes } from "./features/crud/delete_product";
@@ -15,14 +15,16 @@ productRouter.use("/", deleteProductRoutes);
 productRouter.use("/", getProductsRoutes);
 /**
  *  MATCHES:
- *  POST   /api/v1/products          → crear producto
- *  GET    /api/v1/products          → listar productos
- *  GET    /api/v1/products/:id   → detalle por query param
- *  PUT    /api/v1/products/:id      → editar producto
- *  DELETE /api/v1/products/:id      → eliminar producto
+ *  POST   /api/v1/products             → crear producto
+ *  GET    /api/v1/products             → listar productos (page=1, limit=10 por defecto)
+ *  GET    /api/v1/products?page=2&limit=5
+ *                                       → listar productos paginados (ejemplo)
+ *  GET    /api/v1/products/:id         → detalle producto
+ *  PUT    /api/v1/products/:id         → editar producto
+ *  DELETE /api/v1/products/:id         → eliminar producto
  */
 
-//PRODUCT BRAND ( /api/v1/product-brands )
+// PRODUCT BRAND ( /api/v1/products/brands )
 import { createBrandRoutes } from "./features/brand/create_brand/presentation/create_brand.routes";
 import { editBrandRoutes } from "./features/brand/edit_brand/presentation/edit_brand.routes";
 import { deleteBrandRoutes } from "./features/brand/delete_brand/presentation/delete_brand.routes";
@@ -36,11 +38,11 @@ productBrandRouter.use("/", deleteBrandRoutes);
 productBrandRouter.use("/", getBrandRoutes);
 /**
  *  MATCHES:
- *  POST   /api/v1/product-brands        → crear marca
- *  GET    /api/v1/product-brands        → listar marcas (page, limit, search)
- *  GET    /api/v1/product-brands/:id    → detalle de marca
- *  PUT    /api/v1/product-brands/:id    → editar marca
- *  DELETE /api/v1/product-brands/:id    → eliminar marca
+ *  POST   /api/v1/products/brands        → crear marca
+ *  GET    /api/v1/products/brands        → listar marcas
+ *  GET    /api/v1/products/brands/:id    → detalle de marca
+ *  PUT    /api/v1/products/brands/:id    → editar marca
+ *  DELETE /api/v1/products/brands/:id    → eliminar marca
  */
 
 export default productRouter;

--- a/src/modules/visitor/features/create_visitor/data/create_visitor.repository.ts
+++ b/src/modules/visitor/features/create_visitor/data/create_visitor.repository.ts
@@ -2,14 +2,15 @@
 import prisma from "../../../../../config/prisma_client";
 
 export class CreateVisitorRepository {
-  findHostByClientId(client_id: string) {
-    return prisma.client_details.findUnique({
-      where: { client_id },
-      include: {
-        user: true,
-        company: true,
-      },
+  findHostByUserId(user_id: string) {
+    return prisma.users.findUnique({
+      where: { id: user_id },
+      include: { employee_details: { include: { company: true } } },
     });
+  }
+
+  findCompanyById(company_id: string) {
+    return prisma.companies.findUnique({ where: { id: company_id } });
   }
 
   findSpaceById(space_id: string) {
@@ -23,11 +24,12 @@ export class CreateVisitorRepository {
     last_name: string;
     phone?: string | null;
     email?: string | null;
-    client_id: string;
+    host_user_id: string;
+    company_id?: string | null;
     space_id: string;
     entry_time: Date;
     exit_time?: Date | null;
-}) {
+  }) {
     return prisma.visitors.create({ data });
   }
 }

--- a/src/modules/visitor/features/create_visitor/domain/create_visitor.schema.ts
+++ b/src/modules/visitor/features/create_visitor/domain/create_visitor.schema.ts
@@ -1,12 +1,9 @@
 // src/modules/visitor/features/create_visitor/domain/create_visitor.schema.ts
 import { z } from "zod";
 
-// Helper para validar que un campo tenga solo dígitos y longitud exacta
 const onlyDigits = (len: number, field: string) =>
   z
-    .string({
-      invalid_type_error: `El ${field} debe ser una cadena (string)`,
-    })
+    .string({ invalid_type_error: `El ${field} debe ser una cadena (string)` })
     .trim()
     .regex(new RegExp(`^\\d{${len}}$`), {
       message: `El ${field} debe tener exactamente ${len} dígitos`,
@@ -15,7 +12,6 @@ const onlyDigits = (len: number, field: string) =>
 export const CreateVisitorSchema = z
   .object({
     dni: onlyDigits(8, "DNI").optional(),
-
     ruc: onlyDigits(11, "RUC").optional(),
 
     first_name: z
@@ -24,7 +20,6 @@ export const CreateVisitorSchema = z
         invalid_type_error: "El nombre debe ser una cadena (string)",
       })
       .min(1, "El nombre no puede estar vacío"),
-
     last_name: z
       .string({
         required_error: "El apellido es obligatorio",
@@ -37,7 +32,6 @@ export const CreateVisitorSchema = z
         invalid_type_error: "El teléfono debe ser una cadena (string)",
       })
       .optional(),
-
     email: z
       .string({
         invalid_type_error:
@@ -46,12 +40,20 @@ export const CreateVisitorSchema = z
       .email("El formato del correo electrónico no es válido")
       .optional(),
 
-    client_id: z
+    host_user_id: z
       .string({
-        required_error: "El ID del cliente es obligatorio",
-        invalid_type_error: "El ID del cliente debe ser una cadena (UUID)",
+        required_error: "El ID del anfitrión es obligatorio",
+        invalid_type_error: "El ID del anfitrión debe ser una cadena (UUID)",
       })
-      .uuid("El ID del cliente debe ser un UUID válido"),
+      .uuid("El ID del anfitrión debe ser un UUID válido"),
+
+    // ⬇️ nuevo: empresa opcional (si no llega, se tomará la del host si tiene)
+    company_id: z
+      .string({
+        invalid_type_error: "El ID de la empresa debe ser una cadena (UUID)",
+      })
+      .uuid("El ID de la empresa debe ser un UUID válido")
+      .optional(),
 
     space_id: z
       .string({
@@ -83,12 +85,9 @@ export const CreateVisitorSchema = z
     path: ["dni"],
   })
   .refine(
-    (v) => {
-      if (!v.exit_time) return true;
-      return (
-        new Date(v.exit_time).getTime() >= new Date(v.entry_time).getTime()
-      );
-    },
+    (v) =>
+      !v.exit_time ||
+      new Date(v.exit_time).getTime() >= new Date(v.entry_time).getTime(),
     {
       message: "La hora de salida debe ser mayor o igual a la hora de ingreso",
       path: ["exit_time"],

--- a/src/modules/visitor/features/create_visitor/service/create_visitor.controller.ts
+++ b/src/modules/visitor/features/create_visitor/service/create_visitor.controller.ts
@@ -24,8 +24,8 @@ export class CreateVisitorController {
           id: result.id,
           first_name: dto.first_name,
           last_name: dto.last_name,
-        },
-      ),
+        }
+      )
     );
   }
 }

--- a/src/modules/visitor/features/create_visitor/service/create_visitor.routes.ts
+++ b/src/modules/visitor/features/create_visitor/service/create_visitor.routes.ts
@@ -23,37 +23,22 @@ const lookupCtrl = new LookupVisitorController();
  *           schema:
  *             type: object
  *             properties:
- *               dni: { type: string, example: "46027897" }
- *               ruc: { type: string, example: "20601030013" }
- *               first_name: { type: string, example: "ROXANA KARINA" }
- *               last_name: { type: string, example: "DELGADO CUELLAR" }
- *               phone: { type: string, example: "999888777" }
- *               email: { type: string, example: "rdelgado@example.com" }
- *               client_id: { type: string, format: uuid }
- *               space_id: { type: string, format: uuid }
- *               entry_time: { type: string, format: date-time }
- *               exit_time: { type: string, format: date-time }
- *           examples:
- *             manual:
- *               value:
- *                 first_name: "Juan"
- *                 last_name: "Pérez"
- *                 client_id: "uuid-client"
- *                 space_id: "uuid-space"
- *                 entry_time: "2025-08-08T15:30:00.000Z"
- *             with_lookup_dni:
- *               value:
- *                 dni: "46027897"
- *                 first_name: "ROXANA KARINA"
- *                 last_name: "DELGADO CUELLAR"
- *                 client_id: "uuid-client"
- *                 space_id: "uuid-space"
- *                 entry_time: "2025-08-08T15:30:00.000Z"
+ *               dni:          { type: string, example: "46027897" }
+ *               ruc:          { type: string, example: "20601030013" }
+ *               first_name:   { type: string, example: "ROXANA KARINA" }
+ *               last_name:    { type: string, example: "DELGADO CUELLAR" }
+ *               phone:        { type: string, example: "999888777" }
+ *               email:        { type: string, example: "rdelgado@example.com" }
+ *               host_user_id: { type: string, format: uuid, example: "22222222-2222-2222-2222-222222222222" }
+ *               company_id:   { type: string, format: uuid, example: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", description: "Si no se envía, se usará la empresa del anfitrión (si tiene)" }
+ *               space_id:     { type: string, format: uuid, example: "00000000-0000-0000-0000-00000000000b" }
+ *               entry_time:   { type: string, format: date-time, example: "2025-08-28T15:30:00.000Z" }
+ *               exit_time:    { type: string, format: date-time, example: "2025-08-28T18:00:00.000Z" }
  */
 router.post(
   "/",
   authenticateToken,
-  asyncHandler(createCtrl.handle.bind(createCtrl)),
+  asyncHandler(createCtrl.handle.bind(createCtrl))
 );
 
 /**
@@ -74,7 +59,7 @@ router.post(
 router.get(
   "/lookup",
   authenticateToken,
-  asyncHandler(lookupCtrl.handle.bind(lookupCtrl)),
+  asyncHandler(lookupCtrl.handle.bind(lookupCtrl))
 );
 
 export { router as createAndLookupVisitorRoutes };

--- a/src/modules/visitor/features/create_visitor/service/create_visitor.service.ts
+++ b/src/modules/visitor/features/create_visitor/service/create_visitor.service.ts
@@ -13,15 +13,15 @@ export class CreateVisitorService {
     if (user.role !== "admin") {
       throw new AppError(
         MESSAGES.VISITOR.FORBIDDEN,
-        HttpStatusCodes.FORBIDDEN.code,
+        HttpStatusCodes.FORBIDDEN.code
       );
     }
 
-    const host = await this.repo.findHostByClientId(dto.client_id);
+    const host = await this.repo.findHostByUserId(dto.host_user_id);
     if (!host) {
       throw new AppError(
         MESSAGES.VISITOR.HOST_NOT_FOUND,
-        HttpStatusCodes.BAD_REQUEST.code,
+        HttpStatusCodes.BAD_REQUEST.code
       );
     }
 
@@ -29,8 +29,23 @@ export class CreateVisitorService {
     if (!space) {
       throw new AppError(
         MESSAGES.VISITOR.SPACE_NOT_FOUND,
-        HttpStatusCodes.BAD_REQUEST.code,
+        HttpStatusCodes.BAD_REQUEST.code
       );
+    }
+
+    let companyIdToUse: string | null | undefined = undefined;
+
+    if (dto.company_id !== undefined) {
+      const company = await this.repo.findCompanyById(dto.company_id);
+      if (!company) {
+        throw new AppError(
+          MESSAGES.VISITOR.COMPANY_NOT_FOUND,
+          HttpStatusCodes.BAD_REQUEST.code
+        );
+      }
+      companyIdToUse = dto.company_id;
+    } else {
+      companyIdToUse = host.employee_details?.company_id ?? null;
     }
 
     const created = await this.repo.create({
@@ -40,7 +55,8 @@ export class CreateVisitorService {
       last_name: dto.last_name,
       phone: dto.phone ?? null,
       email: dto.email ?? null,
-      client_id: dto.client_id,
+      host_user_id: dto.host_user_id,
+      company_id: companyIdToUse ?? null,
       space_id: dto.space_id,
       entry_time: new Date(dto.entry_time),
       exit_time: dto.exit_time ? new Date(dto.exit_time) : null,

--- a/src/modules/visitor/features/edit_visitor/domain/edit_visitor.schema.ts
+++ b/src/modules/visitor/features/edit_visitor/domain/edit_visitor.schema.ts
@@ -1,33 +1,63 @@
 // src/modules/visitor/features/edit_visitor/domain/edit_visitor.schema.ts
 import { z } from "zod";
 
-export const EditVisitorSchema = z.object({
-  phone: z
-    .string({
-      invalid_type_error: "El teléfono debe ser una cadena (string)",
-    })
-    .optional(),
+const onlyDigits = (len: number, field: string) =>
+  z
+    .string({ invalid_type_error: `El ${field} debe ser una cadena (string)` })
+    .trim()
+    .regex(new RegExp(`^\\d{${len}}$`), {
+      message: `El ${field} debe tener exactamente ${len} dígitos`,
+    });
 
-  email: z
-    .string({
-      invalid_type_error: "El correo electrónico debe ser una cadena (string)",
-    })
-    .email("El formato del correo electrónico no es válido")
-    .optional(),
+export const EditVisitorSchema = z
+  .object({
+    // Datos del visitante
+    dni: onlyDigits(8, "DNI").optional().nullable(),
+    ruc: onlyDigits(11, "RUC").optional().nullable(),
+    first_name: z.string().min(1, "El nombre no puede estar vacío").optional(),
+    last_name: z.string().min(1, "El apellido no puede estar vacío").optional(),
+    phone: z.string().optional().nullable(),
+    email: z
+      .string()
+      .email("El formato del correo electrónico no es válido")
+      .optional()
+      .nullable(),
 
-  exit_time: z
-    .string({
-      invalid_type_error: "La hora de salida debe ser una cadena (string)",
-    })
-    .datetime(
-      "La hora de salida debe estar en formato ISO válido (ej.: 2024-01-31T13:45:00Z)"
-    )
-    .optional(),
+    // Relaciones
+    host_user_id: z
+      .string()
+      .uuid("El ID del anfitrión debe ser un UUID válido")
+      .optional(),
+    company_id: z
+      .string()
+      .uuid("El ID de la empresa debe ser un UUID válido")
+      .optional()
+      .nullable(),
+    space_id: z
+      .string()
+      .uuid("El ID del espacio debe ser un UUID válido")
+      .optional(),
 
-  space_id: z
-    .string({
-      invalid_type_error: "El ID del espacio debe ser una cadena (UUID)",
-    })
-    .uuid("El ID del espacio debe ser un UUID válido")
-    .optional(),
-});
+    // Tiempos
+    entry_time: z.string().datetime("Formato ISO inválido").optional(),
+    exit_time: z.string().datetime("Formato ISO inválido").optional(),
+  })
+  .refine((v) => !(v.dni && v.ruc), {
+    message: "El DNI y el RUC no pueden proporcionarse al mismo tiempo",
+    path: ["dni"],
+  })
+  .refine(
+    (v) => {
+      if (!v.entry_time || !v.exit_time) return true;
+      return (
+        new Date(v.exit_time).getTime() >= new Date(v.entry_time).getTime()
+      );
+    },
+    {
+      message: "La hora de salida debe ser mayor o igual a la hora de ingreso",
+      path: ["exit_time"],
+    }
+  )
+  .refine((v) => Object.values(v).some((val) => val !== undefined), {
+    message: "Debes enviar al menos un campo para actualizar",
+  });

--- a/src/modules/visitor/features/edit_visitor/presentation/edit_visitor.routes.ts
+++ b/src/modules/visitor/features/edit_visitor/presentation/edit_visitor.routes.ts
@@ -45,7 +45,7 @@ const controller = new EditVisitorController();
 router.put(
   "/:id",
   authenticateToken,
-  asyncHandler(controller.handle.bind(controller)),
+  asyncHandler(controller.handle.bind(controller))
 );
 
 export { router as editVisitorRoutes };

--- a/src/modules/visitor/features/edit_visitor/presentation/edit_visitor.service.ts
+++ b/src/modules/visitor/features/edit_visitor/presentation/edit_visitor.service.ts
@@ -13,12 +13,12 @@ export class EditVisitorService {
   async execute(
     id: string,
     body: z.infer<typeof EditVisitorSchema>,
-    user: Pick<CurrentUser, "id" | "role">,
+    user: Pick<CurrentUser, "id" | "role">
   ) {
     if (user.role !== "admin") {
       throw new AppError(
         MESSAGES.VISITOR.FORBIDDEN,
-        HttpStatusCodes.FORBIDDEN.code,
+        HttpStatusCodes.FORBIDDEN.code
       );
     }
 
@@ -26,31 +26,71 @@ export class EditVisitorService {
     if (!existing) {
       throw new AppError(
         MESSAGES.VISITOR.NOT_FOUND,
-        HttpStatusCodes.NOT_FOUND.code,
+        HttpStatusCodes.NOT_FOUND.code
       );
     }
 
+    // Validaciones de existencia para relaciones
     if (body.space_id) {
       const space = await this.repo.findSpaceById(body.space_id);
       if (!space) {
         throw new AppError(
           MESSAGES.VISITOR.SPACE_NOT_FOUND,
-          HttpStatusCodes.BAD_REQUEST.code,
+          HttpStatusCodes.BAD_REQUEST.code
         );
       }
     }
 
+    if (body.host_user_id) {
+      const host = await this.repo.findHostByUserId(body.host_user_id);
+      if (!host) {
+        throw new AppError(
+          MESSAGES.VISITOR.HOST_NOT_FOUND,
+          HttpStatusCodes.BAD_REQUEST.code
+        );
+      }
+    }
+
+    if (body.company_id !== undefined && body.company_id !== null) {
+      const company = await this.repo.findCompanyById(body.company_id);
+      if (!company) {
+        throw new AppError(
+          MESSAGES.VISITOR.COMPANY_NOT_FOUND,
+          HttpStatusCodes.BAD_REQUEST.code
+        );
+      }
+    }
+
+    // Regla: no permitir sobreescribir exit_time si ya existe
     if (existing.exit_time && body.exit_time) {
       throw new AppError(
         MESSAGES.VISITOR.ALREADY_CHECKED_OUT,
-        HttpStatusCodes.CONFLICT.code,
+        HttpStatusCodes.CONFLICT.code
       );
     }
 
+    // Coherencia si cambian entry_time y ya hay exit_time
+    if (body.entry_time && existing.exit_time) {
+      const newEntry = new Date(body.entry_time);
+      if (newEntry.getTime() > new Date(existing.exit_time).getTime()) {
+        throw new AppError(
+          "La nueva hora de ingreso no puede ser mayor que la hora de salida ya registrada",
+          HttpStatusCodes.BAD_REQUEST.code
+        );
+      }
+    }
+
     const updated = await this.repo.update(id, {
-      phone: body.phone ?? null,
-      email: body.email ?? null,
+      dni: body.dni ?? undefined,
+      ruc: body.ruc ?? undefined,
+      first_name: body.first_name ?? undefined,
+      last_name: body.last_name ?? undefined,
+      phone: body.phone ?? undefined,
+      email: body.email ?? undefined,
+      entry_time: body.entry_time ? new Date(body.entry_time) : undefined,
       exit_time: body.exit_time ? new Date(body.exit_time) : undefined,
+      host_user_id: body.host_user_id ?? undefined,
+      company_id: body.company_id ?? undefined, // null = disconnect, uuid = connect
       space_id: body.space_id ?? undefined,
     });
 

--- a/src/modules/visitor/features/get_visitors/domain/get_visitors.schema.ts
+++ b/src/modules/visitor/features/get_visitors/domain/get_visitors.schema.ts
@@ -1,12 +1,10 @@
 // src/modules/visitor/features/get_visitors/domain/get_visitors.schema.ts
 import { z } from "zod";
 
-// Convierte a número > 0; si no, usa el valor por defecto.
 const toNumber = (v: unknown, def: number) => {
   const n = Number(v);
   return Number.isFinite(n) && n > 0 ? n : def;
 };
-
 const isoDateString = z
   .string({
     required_error: "Este campo es obligatorio",
@@ -20,22 +18,22 @@ const isoDateString = z
 export const GetVisitorsQuerySchema = z
   .object({
     page: z
-      .preprocess((v) => toNumber(v, 1), z.number({
-        invalid_type_error: "La página debe ser un número",
-      })
-        .int({ message: "La página debe ser un número entero" })
-        .positive({ message: "La página debe ser mayor a 0" }))
+      .preprocess(
+        (v) => toNumber(v, 1),
+        z
+          .number({ invalid_type_error: "La página debe ser un número" })
+          .int("La página debe ser un número entero")
+          .positive("La página debe ser mayor a 0")
+      )
       .default(1),
 
     limit: z
       .preprocess(
         (v) => Math.min(toNumber(v, 10), 100),
         z
-          .number({
-            invalid_type_error: "El límite debe ser un número",
-          })
-          .int({ message: "El límite debe ser un número entero" })
-          .positive({ message: "El límite debe ser mayor a 0" })
+          .number({ invalid_type_error: "El límite debe ser un número" })
+          .int("El límite debe ser un número entero")
+          .positive("El límite debe ser mayor a 0")
       )
       .default(10),
 
@@ -44,11 +42,11 @@ export const GetVisitorsQuerySchema = z
       .transform((s) => s?.trim() || "")
       .optional(),
 
-    client_id: z
+    host_user_id: z
       .string({
-        invalid_type_error: "El ID del cliente debe ser una cadena (UUID)",
+        invalid_type_error: "El ID del anfitrión debe ser una cadena (UUID)",
       })
-      .uuid("El ID del cliente debe ser un UUID válido")
+      .uuid("El ID del anfitrión debe ser un UUID válido")
       .optional(),
 
     space_id: z
@@ -66,7 +64,10 @@ export const GetVisitorsQuerySchema = z
       v.date_from && v.date_to
         ? new Date(v.date_to) >= new Date(v.date_from)
         : true,
-    { message: "date_to debe ser mayor o igual que date_from", path: ["date_to"] }
+    {
+      message: "date_to debe ser mayor o igual que date_from",
+      path: ["date_to"],
+    }
   );
 
 export const GetVisitorParamSchema = z.object({

--- a/src/modules/visitor/features/get_visitors/presentation/get_visitors.controller.ts
+++ b/src/modules/visitor/features/get_visitors/presentation/get_visitors.controller.ts
@@ -22,8 +22,8 @@ export class GetVisitorsController {
           HttpStatusCodes.OK.code,
           "Visitors list",
           req.path,
-          data,
-        ),
+          data
+        )
       );
   }
 
@@ -37,8 +37,8 @@ export class GetVisitorsController {
           HttpStatusCodes.OK.code,
           "Visitor detail",
           req.path,
-          data,
-        ),
+          data
+        )
       );
   }
 }

--- a/src/modules/visitor/features/get_visitors/presentation/get_visitors.routes.ts
+++ b/src/modules/visitor/features/get_visitors/presentation/get_visitors.routes.ts
@@ -16,15 +16,15 @@ const controller = new GetVisitorsController();
  *     parameters:
  *       - in: query
  *         name: page
- *         schema: { type: integer, example: 1 }
+ *         schema: { type: integer, example: 1, minimum: 1 }
  *       - in: query
  *         name: limit
- *         schema: { type: integer, example: 10, maximum: 100 }
+ *         schema: { type: integer, example: 10, minimum: 1, maximum: 100 }
  *       - in: query
  *         name: search
- *         schema: { type: string, example: "Alicorp" }
+ *         schema: { type: string, example: "roxana" }
  *       - in: query
- *         name: client_id
+ *         name: host_user_id
  *         schema: { type: string, format: uuid }
  *       - in: query
  *         name: space_id
@@ -36,8 +36,8 @@ const controller = new GetVisitorsController();
  *         name: date_to
  *         schema: { type: string, format: date-time, example: "2025-08-31T23:59:59.999Z" }
  *     responses:
- *       200: { description: Lista paginada de visitantes }
- *       400: { description: Parámetros inválidos }
+ *       200:
+ *         description: Lista paginada de visitantes
  */
 router.get("/", asyncHandler(controller.getAll.bind(controller)));
 

--- a/src/modules/visitor/features/get_visitors/presentation/get_visitors.service.ts
+++ b/src/modules/visitor/features/get_visitors/presentation/get_visitors.service.ts
@@ -21,7 +21,7 @@ export class GetVisitorsService {
   }
 
   async getAll(query: z.infer<typeof GetVisitorsQuerySchema>) {
-    const { page, limit, search, client_id, space_id, date_from, date_to } =
+    const { page, limit, search, host_user_id, space_id, date_from, date_to } =
       query;
     const skip = (page - 1) * limit;
 
@@ -30,14 +30,14 @@ export class GetVisitorsService {
         skip,
         take: limit,
         search,
-        client_id,
+        host_user_id,
         space_id,
         date_from: date_from ? new Date(date_from) : undefined,
         date_to: date_to ? new Date(date_to) : undefined,
       }),
       this.repo.count({
         search,
-        client_id,
+        host_user_id,
         space_id,
         date_from: date_from ? new Date(date_from) : undefined,
         date_to: date_to ? new Date(date_to) : undefined,
@@ -45,12 +45,14 @@ export class GetVisitorsService {
     ]);
 
     return {
-      visitors: items,
-      pagination: {
+      items,
+      meta: {
         page,
         limit,
         total,
-        total_pages: Math.ceil(total / limit) || 1,
+        totalPages: Math.ceil(total / limit) || 1,
+        hasNextPage: page * limit < total,
+        hasPrevPage: page > 1,
       },
     };
   }

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -45,8 +45,8 @@ router.use(`${API_VERSION}/payment`, paymentRoutes);
 router.use(`${API_VERSION}/`, attendanceRouter);
 router.use(`${API_VERSION}/`, employeeRouter);
 
+router.use(`${API_VERSION}/products/brands`, productBrandRouter);
 router.use(`${API_VERSION}/products`, productRouter);
-router.use(`${API_VERSION}/products-brands`, productBrandRouter);
 
 router.use(`${API_VERSION}/`, workareaRouter);
 router.use(`${API_VERSION}/`, companyRouter);

--- a/src/utils/pagination/index.ts
+++ b/src/utils/pagination/index.ts
@@ -1,3 +1,4 @@
+// utils/pagination.ts
 const DEFAULT_PAGE = 1;
 const DEFAULT_LIMIT = 10;
 const MAX_LIMIT = 100;
@@ -19,11 +20,8 @@ function buildPaginationMeta(total: number, page: number, limit: number) {
     limit,
     totalPages,
     hasNextPage: page < totalPages,
-    hasPrevPage: page > 1
+    hasPrevPage: page > 1,
   };
 }
 
-export const Pagination = {
-  getPaginationParams,
-  buildPaginationMeta
-};
+export const Pagination = { getPaginationParams, buildPaginationMeta };


### PR DESCRIPTION
## 🔀 Route Separation + Pagination Standardization


This PR reorganizes all API routes by module and implements standardized pagination logic across services, improving scalability and documentation.


---


## 📦 Routes Refactored


### ✅ Before
- Mixed routing paths for products, brands, visitors


### ✅ After
Each module has its own dedicated base route:
- `/api/v1/products` → products (CRUD, filters, detail)
- `/api/v1/product/brands` → product brands (CRUD)
- `/api/v1/visitors` → visitors (create, edit, lookup, filters, pagination)


Structure follows feature-based controller/service/repository pattern for clarity and modularity.


---


## 📄 Pagination Logic Standardized


### ✅ Query Parameters
- `page`: default = 1
- `limit`: default = 10, maximum = 100


### ✅ Service-level Logic
```ts
const skip = (page - 1) * limit;

✅ API Response Format

Each paginated endpoint now returns:

{
"data": [...],
"meta": {
"page": 1,
"limit": 10,
"total": 82,
"total_pages": 9
}
}